### PR TITLE
Let Form API do the redirection instead of sending the response direc…

### DIFF
--- a/src/Form/LoginForm.php
+++ b/src/Form/LoginForm.php
@@ -95,7 +95,8 @@ class LoginForm extends FormBase {
     );
     $scopes = openid_connect_get_scopes();
     $_SESSION['openid_connect_op'] = 'login';
-    $client->authorize($scopes);
+    $response = $client->authorize($scopes, $form_state);
+    $form_state->setResponse($response);
   }
 
 }

--- a/src/Plugin/OpenIDConnectClientBase.php
+++ b/src/Plugin/OpenIDConnectClientBase.php
@@ -7,10 +7,10 @@
 
 namespace Drupal\openid_connect\Plugin;
 
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Exception;
 use Drupal\Core\Url;
 use Drupal\Component\Plugin\PluginBase;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Base class for OpenID Connect client plugins.
@@ -120,8 +120,8 @@ abstract class OpenIDConnectClientBase extends PluginBase implements OpenIDConne
     unset($_GET['destination']);
     $authorization_endpoint = Url::fromUri($endpoints['authorization'], $url_options)->toString();
 
-    $response = new RedirectResponse($authorization_endpoint);
-    return $response->send();
+    $response = new TrustedRedirectResponse($authorization_endpoint);
+    return $response;
   }
 
   /**

--- a/src/Plugin/OpenIDConnectClientInterface.php
+++ b/src/Plugin/OpenIDConnectClientInterface.php
@@ -87,6 +87,8 @@ interface OpenIDConnectClientInterface extends PluginInspectionInterface {
    * @param string $scope
    *   Name of scope(s) that with user consent will provide access to otherwise
    *   restricted user data. Defaults to "openid email".
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
    */
   public function authorize($scope = 'openid email');
 


### PR DESCRIPTION
…tly.

Sending the response directly bypasses Drupal's regular request-reponse
handling which is problematic.

I don't know the API design of the module (or of OpenID Connect), so I can't say whether i.e. it always makes sense for ::authorize() to return a $response, etc. but this at least makes it work.
